### PR TITLE
Fix constructor bug in SearchCoinModel

### DIFF
--- a/lib/app/data/models/crypto/SearchCoinModel.dart
+++ b/lib/app/data/models/crypto/SearchCoinModel.dart
@@ -9,7 +9,6 @@ class SearchCoinModel {
     required this.name,
     required this.symbol,
     required this.thumb,
-    required,
   });
 
   factory SearchCoinModel.fromJson(Map<String, dynamic> json) {


### PR DESCRIPTION
## Summary
- fix a syntax error in `SearchCoinModel`

## Testing
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f544dc69c8328b928726a15826342