### PR TITLE
Fix Coindesk service import path

### DIFF
--- a/lib/app/modules/news/controllers/news_controller.dart
+++ b/lib/app/modules/news/controllers/news_controller.dart
@@ -2,7 +2,7 @@ import 'package:get/get.dart';
 import 'package:flutter/material.dart';
 import 'package:url_launcher/url_launcher.dart';
 import 'package:chartnalyze_apps/app/data/models/news/NewsItemModel.dart';
-import 'package:chartnalyze_apps/app/data/services/news/CoinDeskService.dart';
+import 'package:chartnalyze_apps/app/data/services/news/CoindeskService.dart';
 
 class NewsController extends GetxController {
   final _newsService = CoinDeskService();


### PR DESCRIPTION
## Summary
- correct the NewsController import path to match actual filename

## Testing
- `dart format --output=none --set-exit-if-changed lib/app/modules/news/controllers/news_controller.dart` *(fails: dart not installed)*

------
https://chatgpt.com/codex/tasks/task_e_683f5897c28883289ef0cfc7dc7b0623