### PR TITLE
Fix context null crash

### DIFF
--- a/lib/app/modules/Auth/forgot_password/controllers/forgot_password_controller.dart
+++ b/lib/app/modules/Auth/forgot_password/controllers/forgot_password_controller.dart
@@ -96,8 +96,8 @@ class ForgotPasswordController extends GetxController {
     if (success) {
       Get.snackbar('Success', 'Password updated');
 
-      //  Hindari crash saat dispose controller masih aktif
-      FocusScope.of(Get.context!).unfocus();
+      // Hindari crash saat dispose controller masih aktif
+      FocusManager.instance.primaryFocus?.unfocus();
       await Future.delayed(const Duration(milliseconds: 100));
 
       WidgetsBinding.instance.addPostFrameCallback((_) {


### PR DESCRIPTION
## Summary
- avoid using `Get.context!` when it may be null in forgot password flow

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b4b0c210c8328b321deb24fe8e8a3